### PR TITLE
Added kf_contour_track launch file topic interface 

### DIFF
--- a/lidar_kf_contour_track/include/lidar_kf_contour_track_core.h
+++ b/lidar_kf_contour_track/include/lidar_kf_contour_track_core.h
@@ -143,6 +143,8 @@ protected:
 	tf::TransformListener tf_listener;
 	tf::StampedTransform m_local2global;
 	std_msgs::Header m_InputHeader;
+	std::string m_input_topic;
+	std::string m_output_topic;
 
 	//ROS subscribers
 	ros::NodeHandle nh;

--- a/lidar_kf_contour_track/launch/lidar_kf_contour_track.launch
+++ b/lidar_kf_contour_track/launch/lidar_kf_contour_track.launch
@@ -40,6 +40,8 @@
 	<param name="tracking_type" value="$(arg tracking_type)" /> 
 	<param name="max_association_distance" value="$(arg max_association_distance)" />
 	<param name="max_association_size_diff" value="$(arg max_association_size_diff)" />
+	<param name="tracker_input_topic" value="$(arg tracker_input_topic)" />
+  	<param name="tracker_output_topic" value="$(arg tracker_output_topic)" /> 
 	
 	<param name="max_remeber_time" value="$(arg max_remeber_time)" />
 	<param name="trust_counter" value="$(arg trust_counter)" />		

--- a/lidar_kf_contour_track/nodes/lidar_kf_contour_track/lidar_kf_contour_track_core.cpp
+++ b/lidar_kf_contour_track/nodes/lidar_kf_contour_track/lidar_kf_contour_track_core.cpp
@@ -59,9 +59,9 @@ ContourTracker::ContourTracker()
 	}
 	else
 	{
-		sub_detected_objects = nh.subscribe("/detection/lidar_detector/objects", 1, &ContourTracker::callbackGetDetectedObjects, this);
+		sub_detected_objects = nh.subscribe(m_input_topic, 1, &ContourTracker::callbackGetDetectedObjects, this);
 	}
-	pub_AllTrackedObjects = nh.advertise<autoware_msgs::DetectedObjectArray>("/detection/contour_tracker/objects", 1);
+	pub_AllTrackedObjects = nh.advertise<autoware_msgs::DetectedObjectArray>(m_output_topic, 1);
 	sub_current_pose = nh.subscribe("/current_pose",   1, &ContourTracker::callbackGetCurrentPose, 	this);
 
 	m_VelHandler.InitVelocityHandler(nh, PlannerHNS::CAR_BASIC_INFO(), &m_VehicleStatus, &m_CurrentPos);
@@ -134,6 +134,8 @@ void ContourTracker::ReadNodeParams()
 	_nh.getParam("/lidar_kf_contour_track/enableLogging" , m_Params.bEnableLogging);
 	_nh.getParam("/lidar_kf_contour_track/enableInternalVisualization" , m_Params.bEnableInternalVisualization);
 
+	_nh.getParam("/lidar_kf_contour_track/tracker_input_topic"		, m_input_topic);
+	_nh.getParam("/lidar_kf_contour_track/tracker_output_topic"		, m_output_topic);
 
 	int tracking_type = 0;
 	_nh.getParam("/lidar_kf_contour_track/tracking_type" 			, tracking_type);


### PR DESCRIPTION
Issue:
The launch file of "lidar_kf_contur_track" has the arguments "tracker_input_topic" and "tracker_output_topic". These were not used inside "lidar_kf_contur_track" node before.

Solution:
I have added topic parameters to the node and made input and output topic configurable through the launch file.